### PR TITLE
Upgrade Gradle wrapper to 8.14.3

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,3 +4,7 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.6.0' apply false
-    id "org.jetbrains.kotlin.android" version "2.1.20" apply false
+    id "com.android.application" version '8.13.0' apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
CI's `Android debug build` step started failing on all PRs (e.g. #119):

```
Error: Your project's Gradle version (8.10.0) is lower than Flutter's
minimum supported version of 8.14.0.
```

Flutter `stable` on CI moved to 3.47.0, which requires Gradle >= 8.14.0. This is unrelated to the dependency bumps in #119 — any PR would fail.

- `android/gradle/wrapper/gradle-wrapper.properties`: 8.10 -> 8.14.3
- `android/gradle.properties`: commit the `android.builtInKotlin=false` / `android.newDsl=false` flags the Flutter migrator writes on every build (CI logs "Upgrading gradle.properties" each run); `newDsl=false` also keeps the AGP 9 DSL path off.

Verified locally: `flutter build apk --debug --split-per-abi` succeeds (JDK 21, same as CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)